### PR TITLE
Fix central directory file header CRC32

### DIFF
--- a/index.js
+++ b/index.js
@@ -150,7 +150,7 @@ class Zipfile {
 		} else {
 			const directoryTempl = this.fileCentralDirTempl;
 			const filenameBuffer = fromBuffer(file.relativePath)
-			directoryTempl.writeUIntLE(file.checksum, 16, 4); //crc-32
+			directoryTempl.writeUIntLE(parseInt(file.checksum.toString('hex'), 16), 16, 4); //crc-32
 			directoryTempl.writeInt32LE(file.compressedSize, 20); //compressedSize
 			directoryTempl.writeInt32LE(file.uncompressedSize, 24); //uncompressedSize
 			directoryTempl.writeInt16LE(filenameBuffer.length, 28); //filename length


### PR DESCRIPTION
Archives are currently being created with an empty CRC value (`00000000`), which causes validation errors on extraction (non-zero exit codes using `unzip` on Debian, and `Lambda was not able to unzip the file` errors on AWS Lambda).

Fixes: #13